### PR TITLE
Feat[#28] : RabbitMQ에서 받은 메세지를 바탕으로 유저 선호 가중치를 업데이트하는 기능 추가 

### DIFF
--- a/app/repositories/user_weight_repository.py
+++ b/app/repositories/user_weight_repository.py
@@ -1,5 +1,6 @@
 from typing import List, Dict
-from pymongo import MongoClient
+from pymongo import MongoClient, UpdateOne
+
 
 class UserWeightRepository:
     def __init__(self, mongo_client: MongoClient):
@@ -9,3 +10,18 @@ class UserWeightRepository:
     def find_by_user_id(self, user_id: int) -> List[Dict]:
         results = self.collection.find({"userId": user_id})
         return list(results)
+
+    def update_user_weights(
+        self, user_id: int, meta_info_ids: list[int], weight: float
+    ):
+        operations = []
+        for meta_id in meta_info_ids:
+            operations.append(
+                UpdateOne(
+                    {"user_id": user_id, "meta_info_id": meta_id},
+                    {"$inc": {"weight": weight}},
+                    upsert=True,
+                )
+            )
+        if operations:
+            self.collection.bulk_write(operations)

--- a/app/services/consumer.py
+++ b/app/services/consumer.py
@@ -3,6 +3,7 @@ import aio_pika
 
 QUEUE_NAME = "recommendation.weight.update"
 
+
 async def start_consumer():
     amqp_url = (
         f"amqp://{settings.RABBITMQ_DEFAULT_USER}:{settings.RABBITMQ_DEFAULT_PASS}"
@@ -17,4 +18,13 @@ async def start_consumer():
     async with queue.iterator() as queue_iter:
         async for message in queue_iter:
             async with message.process():
-                print(f"📥 Received: {message.body.decode()}")
+                body = message.body.decode()
+                print(f"📥 Received: {body}")
+                # try:
+                #     data = json.loads(body)
+                #     update_user_weight(
+                #         data,
+                #         repo=UserWeightRepository(mongo_client=settings.MONGO_CLIENT),
+                #     )
+                # except Exception as e:
+                #     print(f"Rabbit MQ로부터의 메세지를 처리하는데 실패하였습니다.: {e}")

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -4,6 +4,7 @@ import numpy as np
 from app.models import db_w2v_mapper
 from app.repositories.user_weight_repository import UserWeightRepository
 
+
 def init_user_vector(genre_map):
     weighted_vectors = []
     total_weight = 0
@@ -22,8 +23,8 @@ def init_user_vector(genre_map):
     user_vector = sum(weighted_vectors) / total_weight
     return str(user_vector.tolist())
 
-def process_user_action(req : UserActionRequestDto, 
-                        repo: UserWeightRepository):
+
+def process_user_action(req: UserActionRequestDto, repo: UserWeightRepository):
     user_id = req.user_id
     # action_type = req.action_type
     # value = req.value
@@ -32,3 +33,16 @@ def process_user_action(req : UserActionRequestDto,
     print(weights)
 
     # todo 가중중치 업데이트
+
+
+def update_user_weight(message: dict, repo: UserWeightRepository):
+    user_id = message.get("userId")
+    meta_info_ids = message.get("metaInfo_Ids", [])
+    weight = message.get("weight", 0.0)
+
+    if not user_id or not meta_info_ids:
+        print("Invalid message:", message)
+        return
+
+    repo.bulk_update_user_weights(user_id, meta_info_ids, weight)
+    print(f" 유저의 가중치 업데이트 성공 : {user_id}")


### PR DESCRIPTION
### 기능 설명

RabbitMQ에서 받은 메세지를 바탕으로 유저 선호 가중치를 업데이트하는 기능을 추가하였습니다. 

기존 flow대로라면 fastapi도 consumer이자 publisher가 되어 mongoDB 업데이트 message를 발행하여야하지만 
현재 구조 상 FastApi와 MongoDB사이의 worker 역할을 하는 중간 서버가 없으므로 
받은 메세지를 기반으로 몽고디비를 업데이트 하는 로직만을 작성하였습니다. 

### 주의 사항 
> consumer.py에서 update 함수를 요청하는 로직은 임시 주석 처리하였습니다. 
