### PR TITLE
Feat[#45] : User Vector 계산 기능 추가 

### DIFF
--- a/app/models/db_w2v_mapper.py
+++ b/app/models/db_w2v_mapper.py
@@ -1,28 +1,30 @@
 _genre_mapping = {
-  "공포": "Horror",
-  "액션": "Action",
-  "스릴러": "Thriller",
-  "미스터리": "Mystery",
-  "가족": "Family",
-  "코미디": "Comedy",
-  "애니메이션": "Animation",
-  "SF": "SF",
-  "다큐멘터리": "Documentary",
-  "판타지": "Fantasy",
-  "드라마": "Drama",
-  "모험": "Adventure",
-  "로맨스": "Romance",
-  "범죄": "Crime",
-  "역사": "History",
-  "음악": "Music",
-  "전쟁": "War",
-  "Action & Adventure": "Adventure",
-  "Sci-Fi & Fantasy": "Fantasy",
-  "Kids": "Children",
-  "War & Politics": "War",
-  "Talk": "Talkshow"
+    "공포": "Horror",
+    "액션": "Action",
+    "스릴러": "Thriller",
+    "미스터리": "Mystery",
+    "가족": "Family",
+    "코미디": "Comedy",
+    "애니메이션": "Animation",
+    "SF": "SF",
+    "다큐멘터리": "Documentary",
+    "판타지": "Fantasy",
+    "드라마": "Drama",
+    "모험": "Adventure",
+    "로맨스": "Romance",
+    "범죄": "Crime",
+    "역사": "History",
+    "음악": "Music",
+    "전쟁": "War",
+    "Action & Adventure": "Adventure",
+    "Sci-Fi & Fantasy": "Fantasy",
+    "Kids": "Children",
+    "War & Politics": "War",
+    "Talk": "Talkshow",
 }
 
-def translate_genre(korean_genre: str) -> str:
-  return _genre_mapping.get(korean_genre, "Unknown")  # 매핑 없을 경우 "Unknown" 반환
 
+def translate_genre(korean_genre: str) -> str:
+    return _genre_mapping.get(
+        korean_genre, "장르가 아닌 metadata는 건너뜁니다"
+    )  # 매핑 없을 경우

--- a/app/models/word2vec_util.py
+++ b/app/models/word2vec_util.py
@@ -1,35 +1,40 @@
+from app.models.db_w2v_mapper import translate_genre
 import numpy as np
 from app.models.word2vec_model import Word2VecModel
 
+
 def calc_user_vector(user_weights):
-  weighted_vectors = []
-  for name, weight in user_weights.items():
-    try:
-      vector = Word2VecModel.get_vector(name)
-      weighted_vectors.append(vector * weight)
-    except KeyError:
-      print(f"[WARN] '{name}' 벡터 없음, 스킵")
-      continue
+    weighted_vectors = []
+    for name, weight in user_weights.items():
+        try:
+            name = translate_genre(name)
+            vector = Word2VecModel.get_vector(name)
+            weighted_vectors.append(vector * weight)
+        except KeyError:
+            print(f"[WARN] '{name}' 벡터 없음, 스킵")
+            continue
 
-  if not weighted_vectors:
-    return []
+    if not weighted_vectors:
+        return []
 
-  avg_vector = np.mean(weighted_vectors, axis=0)
+    avg_vector = np.mean(weighted_vectors, axis=0)
 
-  return avg_vector
+    return avg_vector
+
 
 def get_vector(keyword):
-  return Word2VecModel.get_vector(keyword)
+    return Word2VecModel.get_vector(keyword)
+
 
 def calc_similarity(vec1, vec2):
-  vec1 = np.array(vec1)
-  vec2 = np.array(vec2)
+    vec1 = np.array(vec1)
+    vec2 = np.array(vec2)
 
-  dot_product = np.dot(vec1, vec2)
-  norm1 = np.linalg.norm(vec1)
-  norm2 = np.linalg.norm(vec2)
+    dot_product = np.dot(vec1, vec2)
+    norm1 = np.linalg.norm(vec1)
+    norm2 = np.linalg.norm(vec2)
 
-  if norm1 == 0 or norm2 == 0:
-      return 0.0
+    if norm1 == 0 or norm2 == 0:
+        return 0.0
 
-  return dot_product / (norm1 * norm2)
+    return dot_product / (norm1 * norm2)

--- a/app/repositories/user_weight_repository.py
+++ b/app/repositories/user_weight_repository.py
@@ -27,11 +27,11 @@ class UserWeightRepository:
             self.collection.bulk_write(operations)
 
     async def find_by_user_id(self, user_id: int) -> List[Dict]:
-        cursor = self.collection.find({"userId": user_id})
+        cursor = self.collection.find({"user_id": user_id})
         results = await cursor.to_list(length=None)
         return results
 
     async def reset_weight(self, user_id: int, genre: str, weight: float):
-        filter = {"userId": user_id, "metaInfoName": genre}
+        filter = {"user_id": user_id, "name": genre}
         update = {"$set": {"weight": weight}}
         await self.collection.update_one(filter, update, upsert=True)

--- a/app/services/consumer.py
+++ b/app/services/consumer.py
@@ -1,6 +1,6 @@
 import json
 from app.repositories.user_weight_repository import UserWeightRepository
-from app.services.user_service import update_user_weight
+from app.services.user_service import process_user_action, update_user_weight
 from app.settings.local import settings
 import aio_pika
 from motor.motor_asyncio import AsyncIOMotorClient
@@ -27,7 +27,13 @@ async def start_consumer():
                 print(f"📥 Received: {body}")
                 try:
                     data = json.loads(body)
-                    update_user_weight(
+                    await process_user_action(
+                        data,
+                        UserWeightRepository(
+                            mongo_client=AsyncIOMotorClient(settings.MONGO_URL)
+                        ),
+                    ),
+                    await update_user_weight(
                         data,
                         repo=UserWeightRepository(
                             mongo_client=AsyncIOMotorClient(settings.MONGO_URL)

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -1,4 +1,3 @@
-from app.dto.user_dto import UserActionRequestDto
 from app.enum.action_type import ActionType
 from app.models import word2vec_util
 import numpy as np

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -26,18 +26,31 @@ def init_user_vector(genre_map):
     return str(user_vector.tolist())
 
 
-async def process_user_action(req: UserActionRequestDto, repo: UserWeightRepository):
-    user_id = req.user_id
-    # action_type = req.action_type
-    # value = req.value
+async def process_user_action(message: dict, repo: UserWeightRepository):
+    user_id = message.get("userId")
+    meta_info_names = message.get("metaInfoNames", [])
+    action_type = ActionType[message.get("actionType")]
+    value = message.get("value", 0.0)
+
+    weight_from_message = convert_to_weight(action_type, value)
 
     weights = await repo.find_by_user_id(user_id)
-    print(weights)
 
-    # todo 가중중치 업데이트
+    db_weight_map = {doc.get("name"): doc.get("weight", 0.0) for doc in weights}
+
+    # 기존 가중치와 메시지에서 받은 가중치를 합산
+    combined_weights = {}
+
+    for name in meta_info_names:
+        existing_weight = db_weight_map.get(name, 0.0)
+        combined_weights[name] = existing_weight + weight_from_message
+
+    user_vector = word2vec_util.calc_user_vector(combined_weights)
+
+    print(user_vector)
 
 
-def update_user_weight(message: dict, repo: UserWeightRepository):
+async def update_user_weight(message: dict, repo: UserWeightRepository):
     user_id = message.get("userId")
     meta_info_ids = message.get("metaInfoIds", [])
     meta_info_names = message.get("metaInfoNames", [])


### PR DESCRIPTION
유저 벡터를 계산하는 기능을 추가하였습니다.

메시지 큐에서 수신한 metaInfoNames 리스트와 DB에서 조회한 기존 가중치를 기반으로
- 이름이 일치하는 항목에 대해 가중치를 더하고
- 이를 기반으로 calc_user_vector()를 통해 유저 벡터를 계산합니다.
