### PR TITLE
Refactor[#82] : 유저 가중치 업데이트 시 metaInfo의 type이 추가되도록 변경

### DIFF
--- a/app/models/db_w2v_mapper.py
+++ b/app/models/db_w2v_mapper.py
@@ -29,9 +29,8 @@ def translate_genre(genre: str) -> str | None:
 
     if genre in _genre_mapping:
         return _genre_mapping[genre]
-    
+
     if genre in _genre_mapping.values():
         return genre
 
-    return None
-
+    return genre

--- a/app/repositories/user_weight_repository.py
+++ b/app/repositories/user_weight_repository.py
@@ -13,58 +13,81 @@ class UserWeightRepository:
         self.collection: AsyncIOMotorCollection = self.db["user_weight"]
 
     async def update_user_weights(
-            self, user_id: int, meta_info: list[tuple[int, str]], weight: float
+        self, user_id: int, meta_info: list[tuple[int, str, str]], weight: float
     ):
 
-        meta_info_ids = [meta_id for meta_id, _ in meta_info]
+        meta_info_ids = [meta_id for meta_id, _, _ in meta_info]
 
-        try: # 1. 기존 값 백업
+        try:  # 1. 기존 값 백업
             original_map = await self.backup_original_weights(user_id, meta_info_ids)
         except Exception as e:
             logging.error(f"[백업 실패] user_id={user_id} - {e}")
             raise
 
-        operations = self.build_update_operations(user_id, meta_info, weight) # 2. 업데이트 연산 생성
+        operations = self.build_update_operations(
+            user_id, meta_info, weight
+        )  # 2. 업데이트 연산 생성
 
-        try: # 3. 업데이트 시도
+        try:  # 3. 업데이트 시도
             if operations:
                 await self.collection.bulk_write(operations)
                 logging.info(f"[가중치 업데이트 성공] user_id={user_id}")
         except Exception as e:
             logging.error(f"[업데이트 실패 - 롤백 시작] user_id={user_id} - {e}")
             await self.rollback_weights(user_id, meta_info, original_map)
-            raise # 로그를 남길 수 있도록 예외 throw 처리
+            raise  # 로그를 남길 수 있도록 예외 throw 처리
 
-    async def backup_original_weights(self, user_id: int, meta_info_ids: list[int]) -> dict:
-        cursor = self.collection.find({
-            "user_id": user_id,
-            "meta_info_id": {"$in": meta_info_ids}
-        })
+    async def backup_original_weights(
+        self, user_id: int, meta_info_ids: list[int]
+    ) -> dict:
+        cursor = self.collection.find(
+            {"user_id": user_id, "meta_info_id": {"$in": meta_info_ids}}
+        )
         docs = await cursor.to_list(length=None)
         return {doc["meta_info_id"]: doc.get("weight", 0.0) for doc in docs}
 
-    def build_update_operations(self, user_id: int, meta_info: list[tuple[int, str]], weight: float):
+    def build_update_operations(
+        self, user_id: int, meta_info: list[tuple[int, str, str]], weight: float
+    ):
         ops = []
-        for meta_id, name in meta_info:
+        for meta_id, name, meta_type in meta_info:
             translated_name = db_w2v_mapper.translate_genre(name)
-            ops.append(UpdateOne(
-                {"user_id": user_id, "meta_info_id": meta_id},
-                {"$inc": {"weight": weight}, "$set": {"name": translated_name}},
-                upsert=True
-            ))
+            ops.append(
+                UpdateOne(
+                    {
+                        "user_id": user_id,
+                        "meta_info_id": meta_id,
+                    },
+                    {
+                        "$inc": {"weight": weight},
+                        "$set": {"name": translated_name, "type": meta_type},
+                    },
+                    upsert=True,
+                )
+            )
         return ops
 
-    async def rollback_weights(self, user_id: int, meta_info: list[tuple[int, str]], original_map: dict):
+    async def rollback_weights(
+        self, user_id: int, meta_info: list[tuple[int, str, str]], original_map: dict
+    ):
         rollback_ops = []
-        for meta_id, name in meta_info:
+        for meta_id, name, meta_type in meta_info:
             if meta_id not in original_map:
                 continue
             translated = db_w2v_mapper.translate_genre(name)
-            rollback_ops.append(UpdateOne(
-                {"user_id": user_id, "meta_info_id": meta_id},
-                {"$set": {"weight": original_map[meta_id], "name": translated}},
-                upsert=True
-            ))
+            rollback_ops.append(
+                UpdateOne(
+                    {"user_id": user_id, "meta_info_id": meta_id},
+                    {
+                        "$set": {
+                            "weight": original_map[meta_id],
+                            "name": translated,
+                            "type": meta_type,
+                        }
+                    },
+                    upsert=True,
+                )
+            )
 
         if rollback_ops:
             try:
@@ -72,8 +95,10 @@ class UserWeightRepository:
                 logging.info(f"[롤백 완료] user_id={user_id}")
             except Exception as rollback_err:
                 logging.error(f"[롤백 실패] user_id={user_id} - {rollback_err}")
-                raise # 예외 던지기
-        raise RuntimeError(f"[업데이트 실패로 인한 롤백 후 예외 재전파] user_id={user_id}")
+                raise  # 예외 던지기
+        raise RuntimeError(
+            f"[업데이트 실패로 인한 롤백 후 예외 재전파] user_id={user_id}"
+        )
 
     async def find_by_user_id(self, user_id: int) -> List[Dict]:
         cursor = self.collection.find({"user_id": user_id})

--- a/app/services/redis.py
+++ b/app/services/redis.py
@@ -32,7 +32,6 @@ async def close_redis():
 
 async def save_user_vector(user_id: int, value: str):
     try:
-        print(f"📝 Redis 저장 시작: user_id={user_id}")
         await get_redis().set(str(user_id), value)
         print(f"✅ Redis 저장 완료: user_id={user_id}")
     except Exception as e:

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -30,7 +30,6 @@ def init_user_vector(genre_map):
 async def process_user_action(
     message: dict, userRepo: UserWeightRepository, actionLogRepo: ActionLogRepository
 ):
-    print("processing user action 호출 ")
     user_id = message.get("userId")
     meta_info_names = message.get("metaInfoNames", [])
     action_type = ActionType[message.get("actionType")]
@@ -39,7 +38,6 @@ async def process_user_action(
     weight_from_message = convert_to_weight(action_type, value)
 
     weights = await userRepo.find_by_user_id(user_id)
-    print("userRepo.find_by_user_id 호출 성공 ")
 
     db_weight_map = {doc.get("name"): doc.get("weight", 0.0) for doc in weights}
     combined_weights = {}
@@ -49,11 +47,8 @@ async def process_user_action(
         combined_weights[name] = existing_weight + weight_from_message
 
     user_vector = word2vec_util.calc_user_vector(combined_weights)
-    print("user_vector 계산 성공")
     user_vector_str = np.array2string(user_vector, separator=", ")
-    print("user_vector_str 변환 성공")
     await save_user_vector(user_id, user_vector_str)
-    print("Redis에 유저 벡터 저장 성공")
     await actionLogRepo.mark_status(
         collection_names=["action_log", "managed_action_log"],
         doc_id=message["id"],
@@ -66,6 +61,8 @@ async def update_user_weight(message: dict, repo: UserWeightRepository):
     user_id = message.get("userId")
     meta_info_ids = message.get("metaInfoIds", [])
     meta_info_names = message.get("metaInfoNames", [])
+    meta_info_types = message.get("metaInfoTypes", [])
+
     action_type = ActionType[message.get("actionType")]
     value = message.get("value", 0.0)
 
@@ -75,6 +72,6 @@ async def update_user_weight(message: dict, repo: UserWeightRepository):
         print("Invalid message:", message)
         return
 
-    meta_info = list(zip(meta_info_ids, meta_info_names))
+    meta_info = list(zip(meta_info_ids, meta_info_names, meta_info_types))
     await repo.update_user_weights(user_id, meta_info, weight)
     print(f" 유저의 가중치 업데이트 성공 : {user_id}")


### PR DESCRIPTION
## 확인 사항
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용

Rabbit MQ 메세지를 consume 한 후 사용자 가중치 업데이트를 할 때 
mongo DB의 user_weights 컬렉션에 meta_info_type이 추가되도록 합니다 

## 주의사항

Closes #82 
